### PR TITLE
Add a couple of video playing props for greater control and manipulation of video playing

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,4 +302,25 @@ The `<VideoPlayer/>` component has the following configuration properties:
     <td>❌</td>
     <td>undefined</td>
   </tr>
+  <tr>
+    <td>children</td>
+    <td>JSX</td>
+    <td>child components to be rendered under video player controls</td>
+    <td>❌</td>
+    <td>undefined</td>
+  </tr>
+  <tr>
+    <td>onPostProgress</td>
+    <td>function</td>
+    <td>callback function that is called every progressUpdateInterval milliseconds with info about which position the media is currently playing</td>
+    <td>❌</td>
+    <td>undefined
+  </tr>
+  <tr>
+    <td>onPostSeek</td>
+    <td>function</td>
+    <td>callback function that is called when a seek completes</td>
+    <td>❌</td>
+    <td>undefined
+  </tr>
 </table>

--- a/example/src/screens/video.tsx
+++ b/example/src/screens/video.tsx
@@ -569,6 +569,8 @@ export const VideoScreen = ({
               resizeMode="cover"
               isFullScreen={isFullScreen}
               disableControl={diasbled}
+              onPostProgress={() => console.log('onProgress')}
+              onPostSeek={() => console.log('onSeek')}
               renderBackIcon={() => (
                 <Icon
                   name="a-ic_chevrondown_16"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -95,6 +95,9 @@ export type VideoProps = VideoProperties & {
   onVideoPlayEnd?: () => void;
   onAutoPlayText?: string;
   offAutoPlayText?: string;
+  children?: any;
+  onPostProgress?: (data: OnProgressData) => void;
+  onPostSeek?: (data: OnSeekData) => void;
 };
 export type VideoPlayerRef = {
   /**
@@ -160,6 +163,9 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoProps>(
       onVideoPlayEnd,
       onAutoPlayText = 'Autoplay is on',
       offAutoPlayText = 'Autoplay is off',
+      children,
+      onPostProgress,
+      onPostSeek,
       ...rest
     },
     ref,
@@ -677,6 +683,9 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoProps>(
       } else {
         isSeeking.current = false;
       }
+      if (onPostSeek) {
+        onPostSeek(data);
+      }
     };
 
     /**
@@ -685,12 +694,16 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoProps>(
      *
      * @param {object} data The video meta data
      */
-    const onProgress = ({ currentTime: cTime }: OnProgressData) => {
+     const onProgress = (data: OnProgressData) => {
+      const { currentTime: cTime } = data;
       if (!isScrubbing.value) {
         if (!isSeeking.current) {
           progress.value = cTime;
         }
         setCurrentTime(cTime);
+      }
+      if (onPostProgress) {
+        onPostProgress(data);
       }
     };
     /**
@@ -838,6 +851,7 @@ const VideoPlayer = forwardRef<VideoPlayerRef, VideoProps>(
               onProgress={onProgress}
               fullscreenAutorotate={true}
             />
+            {Boolean(children) && children}
             <VideoLoader loading={loading} />
             <Animated.View style={StyleSheet.absoluteFillObject}>
               <Animated.View style={[styles.controlView, controlViewStyles]}>


### PR DESCRIPTION
Add a couple of video playing props for greater control and manipulation of video playing.
- Add 'onPostProgress' prop which is a callback function that is called every progressUpdateInterval milliseconds with info about which position the media is currently playing. This prop is called directly after react-native-reanimated-player functions and relies on [react-native-video onProgress](https://github.com/react-native-video/react-native-video/blob/master/API.md#onprogress)
- Add 'onSeek' prop which is a callback function that is called when a seek completes.This prop is called directly after react-native-reanimated-player functions and relies on [react-native-video onSeek](https://github.com/react-native-video/react-native-video/blob/master/API.md#onseek)
- Explicitly add 'children' prop so that child components can be added in between the video and the video player controls.